### PR TITLE
CRISTALNC-18: Missing home page in default wiki configuration

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -47,6 +47,7 @@ CristalAppLoader.init(
         baseURL: window.location.origin,
         baseRestURL: `${window.location.origin}/remote.php/dav`,
         editor: "blocknote",
+        homePage: "home",
       },
     };
   },


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/CRISTALNC-18

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

Just adds the missing attribute.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

N/A

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Built, installed and tested locally. Also patched release 1.1.0 through devtools.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A