### PR TITLE
CRISTALNC-23: Force light theme

### DIFF
--- a/src/ds/vue/css/style.css
+++ b/src/ds/vue/css/style.css
@@ -39,7 +39,7 @@ div#xwCristalApp {
   --cr-sizes-main-sidebar-min-width: 250px; /*The minimum width of the main sidebar*/
   --cr-sizes-collapsed-main-sidebar-width: 32px; /*The width of the bar that gets shown containing the menu button to reopen the standard main main sidebar*/
   --cr-base-font-size: 16px;
-  --cr-base-text-color: var(--cr-color-gray-950);
+  --cr-base-text-color: var(--color-main-text);
   --cr-base-link-color: var(--cr-color-sky-700);
   --cr-base-visited-link-color: var(--cr-color-blue-700);
   --cr-mute-text-color: var(--cr-color-neutral-600);

--- a/src/ds/vue/css/style.css
+++ b/src/ds/vue/css/style.css
@@ -33,7 +33,7 @@ main ul, main ol {
   padding-inline-start: var(--cr-spacing-x-large);
 }
 
-body {
+div#xwCristalApp {
   --cr-sizes-max-page-width: 960px; /*This value controls the width of the main content. It should be 100% for spanning text along the whole width or an arbitraty value*/
   --cr-sizes-main-sidebar-width: 15%; /*The default width of the main sidebar*/
   --cr-sizes-main-sidebar-min-width: 250px; /*The minimum width of the main sidebar*/

--- a/src/main.css
+++ b/src/main.css
@@ -21,7 +21,11 @@
 /* This targets the "content" node used by the Nextcloud wrapper. */
 div#content {
   display: grid;
+}
+
+div#xwCristalApp {
   background-color: var(--cr-panel-background-color);
+  color: var(--cr-base-text-color);
 }
 
 /* This targets the "content" node used by Cristal. */

--- a/templates/index.php
+++ b/templates/index.php
@@ -28,4 +28,4 @@ Util::addScript(OCA\Cristal\AppInfo\Application::APP_ID, OCA\Cristal\AppInfo\App
 Util::addStyle(OCA\Cristal\AppInfo\Application::APP_ID, OCA\Cristal\AppInfo\Application::APP_ID . '-main');
 
 ?>
-<div id="xwCristalApp" class="xw-cristal"></div>
+<div id="xwCristalApp" class="xw-cristal" data-theme-light></div>

--- a/templates/index.php
+++ b/templates/index.php
@@ -28,4 +28,5 @@ Util::addScript(OCA\Cristal\AppInfo\Application::APP_ID, OCA\Cristal\AppInfo\App
 Util::addStyle(OCA\Cristal\AppInfo\Application::APP_ID, OCA\Cristal\AppInfo\Application::APP_ID . '-main');
 
 ?>
+<!-- TODO: Remove data-theme-light once CRISTALNC-22 is fixed. -->
 <div id="xwCristalApp" class="xw-cristal" data-theme-light></div>


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/CRISTALNC-23

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

Temporarily force the application to use Nextcloud's light theme, no matter the user's settings.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

This is necessary until https://jira.xwiki.org/browse/CRISTALNC-22 is fixed.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
<img width="1440" height="960" alt="image" src="https://github.com/user-attachments/assets/7ae42579-3d02-4745-afab-6c1fdef65dd0" />

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Built, installed and tested locally.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A