### PR TITLE
CRISTALNC-36: New page modal parent location field

### DIFF
--- a/src/ds/vue/form/x-text-field.vue
+++ b/src/ds/vue/form/x-text-field.vue
@@ -34,7 +34,8 @@ defineProps<TextFieldProps>()
 		:helperText="help"
 		:readonly="readonly"
 		:required="required"
-		:type="type ?? 'text'">
+		:type="type ?? 'text'"
+		:class="{ 'x-text-field--slotted': $slots.default }">
 		<template v-if="$slots.default" #icon>
 			<slot name="default" />
 		</template>
@@ -50,4 +51,42 @@ defineProps<TextFieldProps>()
   width: unset;
 }
 
+/*
+ * NcTextField only exposes a leading-icon slot for custom content, sized for a
+ * single icon. When arbitrary content is slotted (e.g. a location breadcrumb),
+ * let it span the whole field content area, left aligned, and hide the unused
+ * input value behind it, so it is not cramped into the leading-icon box.
+ */
+.x-text-field--slotted :deep(.input-field__icon--leading) {
+  position: absolute;
+  inset-inline: 0;
+  inset-block: 0;
+  width: auto;
+  align-items: center;
+  justify-content: flex-start;
+  padding-inline: var(--input-padding-start, var(--border-radius-element));
+  overflow: hidden;
+}
+
+.x-text-field--slotted :deep(.input-field__input) {
+  color: transparent;
+}
+
+/*
+ * A breadcrumb is a chunky nav widget; compact it so it sits on the field value
+ * line without overflowing over the floating label above.
+ */
+.x-text-field--slotted :deep(.breadcrumb),
+.x-text-field--slotted :deep(.breadcrumb nav),
+.x-text-field--slotted :deep(.breadcrumb ul),
+.x-text-field--slotted :deep(.breadcrumb li) {
+  min-height: 0;
+  height: auto;
+}
+
+.x-text-field--slotted :deep(.breadcrumb .button-vue) {
+  min-height: 0;
+  height: var(--clickable-area-small, 28px);
+  padding-block: 0;
+}
 </style>


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTALNC-36

# Changes

## Description

* The parent-location breadcrumb shown in the new page / move page dialog was rendered inside `NcTextField`'s leading-icon slot (the only slot the Nextcloud `x-text-field` exposes for custom content). That slot is sized for a single icon, so the breadcrumb was cropped to a couple of characters (e.g. just "S") and overlapped the field label.
* When custom content is slotted into `x-text-field`, it now spans the whole field content area (left aligned, with the unused input value hidden behind it), and the breadcrumb is compacted so it sits on the field value line without overflowing over the floating label.

## Clarifications

* This is the Nextcloud-design-system side of CRISTALNC-36. The behavioral fixes (breadcrumb segments no longer navigate, selection only applied on "Select", current page as default parent location, dialog no longer overflowing horizontally) are in the Cristal core PR xwiki-contrib/cristal#1715; this PR only makes the slotted content render correctly in the Nextcloud design system's `x-text-field`.
* The styling is scoped to `x-text-field` instances that actually receive slotted content (`.x-text-field--slotted`), so ordinary text fields (e.g. the page name field) are unaffected.

# Screenshots & Video

Before: the parent location field showed only the first character of the location ("S"), cramped in the leading-icon area. After: the location breadcrumb is displayed across the field, under the "Parent location" label.

# Executed Tests

* `pnpm lint` and `pnpm stylelint` pass.
* `pnpm build` succeeds.
* Reproduced and validated against the real `@nextcloud/vue` `NcTextField` + `NcBreadcrumbs` in a standalone harness (with the Nextcloud global CSS variables): the breadcrumb spans the field and no longer overlaps the label, for both a single-segment and a deep location; the change is gated on the `.x-text-field--slotted` class so plain text fields are unaffected. Deployed to a local Nextcloud instance for manual verification.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: none
