### PR TITLE
CRISTALNC-46: Attachment section overlaps right sidebar after reopening sidebar

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -42,6 +42,11 @@ article#content .breadcrumb {
   height: unset;
 }
 
+/* This targets NC's sidebar elements we embed in the article section. */
+article#content .app-sidebar {
+  z-index: inherit;
+}
+
 article#content:not(.with-sidebar--full) {
   position: unset;
 }


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTALNC-46

# Changes

## Description

In Nextcloud's design system, we rely on components that are officially designed as sidebar elements.

This PR simply resets the z-index value for these if they are actually in the article section.

## Clarifications

N/A

# Screenshots & Video

N/A

# Executed Tests

Tested manually.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: none