### PR TITLE
CRISTALNC-31: h1 are not wysiwyg

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -28,6 +28,18 @@ div#xwCristalApp {
   color: var(--cr-base-text-color);
 }
 
+/* This targets the "view mode" content in Cristal. */
+div#xwikicontent {
+  h1 {
+    font-size: 2em;
+    font-weight: 600;
+    line-height: 1.5;
+    margin-top: 24px;
+    margin-bottom: 12px;
+    color: var(--color-main-text);
+  }
+}
+
 /* This targets the "content" node used by Cristal. */
 article#content {
   display: grid;


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTALNC-31

# Changes

## Description

The apps style for Nextcloud ignores `h1` elements because it uses it's reserved to display the app logo. Since we do not use this feature, this PR sets the same style as other headers for `h1`, with a bigger font than `h2`, but only in `xwikicontent` (since Cristal already has custom definitions in the page header and the editor).

## Clarifications

N/A

# Screenshots & Video

N/A

# Executed Tests

Tested manually.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: none